### PR TITLE
Add crawler/agent standards: gitignore, robots.txt, llms.txt, agent-manifest.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ temp/
 
 # OS
 Thumbs.db
+
+# Internal docs — session notes, planning, and development docs
+# These should never be committed to the public website repo.
+# Files already in the repo: use `git rm --cached` to untrack without deleting.
+docs/session-notes/
+docs/development/
+docs/WEBSITE_EVOLUTION_PLAN.md
+docs/security/

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ Thumbs.db
 # Internal docs — session notes, planning, and development docs
 # These should never be committed to the public website repo.
 # Files already in the repo: use `git rm --cached` to untrack without deleting.
-docs/session-notes/
-docs/development/
-docs/WEBSITE_EVOLUTION_PLAN.md
-docs/security/
+# Note: _config.yml also excludes docs/ from the Jekyll build as defense in depth.
+# If public-facing docs are ever added under docs/, update both files intentionally.
+docs/

--- a/.well-known/agent-manifest.txt
+++ b/.well-known/agent-manifest.txt
@@ -1,0 +1,54 @@
+# Agent Manifest — DollhouseMCP
+# Format: agent-manifest.txt (formerly agents.txt)
+# Spec reference: https://dev.to/jaspervanveen/agentstxt-a-proposed-web-standard-for-ai-agents-20lb
+# Site: https://dollhousemcp.com
+# Last updated: 2026-04-13
+
+## Identity
+
+name: DollhouseMCP
+organization: Dollhouse Research (DollhouseMCP Inc.)
+site: https://dollhousemcp.com
+contact: contact@dollhousemcp.com
+type: open-source-project-documentation
+
+## Site Description
+
+DollhouseMCP is an open-source AI customization system built on the Model Context
+Protocol (MCP). This site provides documentation, blog content, and licensing
+information. It is a static informational site — no user accounts, no transactional
+forms, no checkout flows.
+
+## Permissions for AI Agents
+
+Agents MAY:
+- Read and index all content under / except Disallow paths in robots.txt
+- Follow links to external resources (GitHub, npm, collection, mcpaql.com)
+- Use content for summarization, question answering, and research
+- Access llms.txt at https://dollhousemcp.com/llms.txt for structured site overview
+
+Agents MUST NOT:
+- Submit forms on behalf of users (no forms exist on this site)
+- Attempt authentication or session creation
+- Crawl /docs/ (internal development documents, see robots.txt)
+- Cache or republish full page content beyond fair-use excerpts without attribution
+
+## MCP Integration
+
+DollhouseMCP itself is an MCP server. AI agents that support MCP can interact with
+the DollhouseMCP server directly rather than scraping this website.
+
+Install: npx @dollhousemcp/mcp-server@latest --web
+Protocol: Model Context Protocol (MCP)
+Query layer: MCP-AQL (https://mcpaql.com)
+
+## Licensing
+
+Site content: CC BY 4.0 unless otherwise noted
+Software: AGPL-3.0-or-later
+Element collection: per-element licensing (see https://collection.dollhousemcp.com)
+
+## Attribution
+
+When citing or summarizing content from this site, please attribute as:
+"DollhouseMCP by Mick Darling / Dollhouse Research — https://dollhousemcp.com"

--- a/.well-known/agent-manifest.txt
+++ b/.well-known/agent-manifest.txt
@@ -1,10 +1,12 @@
+---
+---
 # Agent Manifest — DollhouseMCP
 # Format: agent-manifest.txt (formerly agents.txt)
 # Spec reference: https://dev.to/jaspervanveen/agentstxt-a-proposed-web-standard-for-ai-agents-20lb
 # Note: agent-manifest.txt is an emerging proposal, not yet a finalized standard.
 # This file should be reviewed and updated when a stable spec is published.
 # Site: https://dollhousemcp.com
-# Last updated: 2026-04-14
+# Last updated: {{ site.time | date: "%Y-%m-%d" }}
 
 ## Identity
 

--- a/.well-known/agent-manifest.txt
+++ b/.well-known/agent-manifest.txt
@@ -1,8 +1,10 @@
 # Agent Manifest — DollhouseMCP
 # Format: agent-manifest.txt (formerly agents.txt)
 # Spec reference: https://dev.to/jaspervanveen/agentstxt-a-proposed-web-standard-for-ai-agents-20lb
+# Note: agent-manifest.txt is an emerging proposal, not yet a finalized standard.
+# This file should be reviewed and updated when a stable spec is published.
 # Site: https://dollhousemcp.com
-# Last updated: 2026-04-13
+# Last updated: 2026-04-14
 
 ## Identity
 

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ exclude:
   - CLAUDE.md
   - .git
   - .github
-  - docs/security
+  - docs
   - mockups
   - SECURITY.md
   - vendor

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,7 @@ as @dollhousemcp/mcp-server on npm.
 - [Dynamic Permissioning](https://dollhousemcp.com/dynamic-permissioning.html): Gatekeeper policies, allow/deny/confirm patterns, and per-operation approval flows
 - [MCP-AQL](https://dollhousemcp.com/mcp-aql.html): The structured query layer built on MCP — CRUDE routing, semantic endpoints, runtime discovery
 - [Portfolio Workflows](https://dollhousemcp.com/portfolio-workflows.html): Three-tier architecture — local portfolio, GitHub backup, community collection
+- [Platform Operations](https://dollhousemcp.com/platform-operations.html): Full platform surface — portfolio management, collection workflows, skill conversion, search, and execution lifecycle control
 - [Starter Elements](https://dollhousemcp.com/starter-elements.html): The 38 bundled elements included with installation
 - [Licensing](https://dollhousemcp.com/licensing.html): AGPL-3.0 default, free commercial tier (under $1M revenue), enterprise options
 - [About](https://dollhousemcp.com/about.html): Project background, mission, and founder information
@@ -45,4 +46,5 @@ as @dollhousemcp/mcp-server on npm.
 
 ## Optional
 
-- [Style Guide](https://dollhousemcp.com/style-guide.html): Internal design system reference
+- [Blog Index](https://dollhousemcp.com/blog/): Full list of all posts
+- [Releases](https://github.com/DollhouseMCP/mcp-server/releases): Changelog and version history

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,48 @@
+# DollhouseMCP
+
+> Open-source AI customization through modular, composable elements. DollhouseMCP lets
+> you build personas, skills, templates, agents, memories, and ensembles as portable
+> YAML files — then snap them together like Lego blocks. Runs on the Model Context
+> Protocol (MCP) standard. AGPL-3.0 licensed.
+
+DollhouseMCP 2.0 is a local-first element system for AI customization. Elements live
+in ~/.dollhouse/portfolio/ on your machine, sync optionally to GitHub, and can be
+shared through the Dollhouse Collection community library. The server exposes a
+structured query layer (MCP-AQL) that reduces tool-definition token overhead by
+85–96% compared to discrete tool definitions.
+
+The project is maintained by Dollhouse Research (dollhouseresearch.com) and published
+as @dollhousemcp/mcp-server on npm.
+
+## Core Documentation
+
+- [Home](https://dollhousemcp.com/): Overview, quick-start install command, and feature summary
+- [Building Blocks](https://dollhousemcp.com/building-blocks.html): The six element types — personas, skills, templates, agents, memories, ensembles
+- [Agent Runtime](https://dollhousemcp.com/agent-runtime.html): How agents execute, the Gatekeeper permission system, and autonomy evaluation
+- [Dynamic Permissioning](https://dollhousemcp.com/dynamic-permissioning.html): Gatekeeper policies, allow/deny/confirm patterns, and per-operation approval flows
+- [MCP-AQL](https://dollhousemcp.com/mcp-aql.html): The structured query layer built on MCP — CRUDE routing, semantic endpoints, runtime discovery
+- [Portfolio Workflows](https://dollhousemcp.com/portfolio-workflows.html): Three-tier architecture — local portfolio, GitHub backup, community collection
+- [Starter Elements](https://dollhousemcp.com/starter-elements.html): The 38 bundled elements included with installation
+- [Licensing](https://dollhousemcp.com/licensing.html): AGPL-3.0 default, free commercial tier (under $1M revenue), enterprise options
+- [About](https://dollhousemcp.com/about.html): Project background, mission, and founder information
+
+## Blog
+
+- [A Tour of the DollhouseMCP Console](https://dollhousemcp.com/blog/dollhousemcp-console-tour/): Walkthrough of the local web console — setup, portfolio browser, live logs, metrics, permissions (April 2026)
+- [The Story Behind DollhouseMCP](https://dollhousemcp.com/blog/story-behind-dollhousemcp/): How a prompt catalog evolved into a modular element system (September 2025)
+- [Meta-Development: Agents Built Their Own Documentation](https://dollhousemcp.com/blog/meta-development-dollhousemcp-agents-build-themselves/): Using DollhouseMCP agents to generate documentation across three repos (September 2025)
+- [The 15-Minute Mystery: AI Agents Chase Ghosts in CI/CD](https://dollhousemcp.com/blog/the-15-minute-mystery-ai-agents-chase-ghosts-in-ci/): CI hanging issue turned non-problem — lessons on AI agents and assumptions (August 2025)
+- [Mobile Development Workflow with Blink, tmux, and Claude Code](https://dollhousemcp.com/blog/mobile-development-workflow-blink-tmux-claude/): Building an MCP server from an iPhone (August 2025)
+- [Fixing the MCP Server Disconnected Error](https://dollhousemcp.com/blog/fixing-mcp-server-disconnected-claude-desktop/): Debugging npx/CLI execution detection for MCP servers (August 2025)
+
+## External Resources
+
+- [GitHub Repository](https://github.com/DollhouseMCP/mcp-server): Source code, issues, and contribution guide
+- [npm Package](https://www.npmjs.com/package/@dollhousemcp/mcp-server): Install via npx @dollhousemcp/mcp-server@latest --web
+- [Dollhouse Collection](https://collection.dollhousemcp.com/): Community library of contributed elements
+- [MCP-AQL Protocol](https://mcpaql.com/): Specification, adapter patterns, and documentation
+- [Dollhouse Research](https://dollhouseresearch.com/): Parent organization — DollhouseMCP, Collection, and MCPAQL projects
+
+## Optional
+
+- [Style Guide](https://dollhousemcp.com/style-guide.html): Internal design system reference

--- a/robots.txt
+++ b/robots.txt
@@ -7,7 +7,6 @@
 User-agent: *
 Allow: /
 Disallow: /docs/
-Disallow: /style-guide.html
 
 # Block bad bots and scrapers
 User-agent: AhrefsBot
@@ -26,14 +25,12 @@ Sitemap: https://dollhousemcp.com/sitemap.xml
 # llms.txt: https://dollhousemcp.com/llms.txt
 # agent-manifest: https://dollhousemcp.com/.well-known/agent-manifest.txt
 
-# Security.txt location for security researchers
+# Security.txt location for security researchers (non-standard directive — informational only)
 # See https://securitytxt.org/
-Security.txt: https://dollhousemcp.com/.well-known/security.txt
+# Security.txt: https://dollhousemcp.com/.well-known/security.txt
 
 # Crawl-delay to be respectful of resources (in seconds)
 # Most modern bots ignore this, but it's good practice
 Crawl-delay: 1
 
-# Specify preference for HTTPS (though most bots use HTTPS by default now)
-# This is a non-standard directive but doesn't hurt
-Prefer-https: true
+# Prefer-https: true (non-standard, ignored by compliant parsers — omitted for RFC 9309 cleanliness)

--- a/robots.txt
+++ b/robots.txt
@@ -20,9 +20,11 @@ Disallow: /
 # Sitemap
 Sitemap: https://dollhousemcp.com/sitemap.xml
 
-# LLM and agent discovery
-llms.txt: https://dollhousemcp.com/llms.txt
-agent-manifest: https://dollhousemcp.com/.well-known/agent-manifest.txt
+# LLM and agent discovery (informational — not standard robots.txt directives,
+# but useful as human-readable pointers; crawlers that support these standards
+# fetch these paths directly from the root)
+# llms.txt: https://dollhousemcp.com/llms.txt
+# agent-manifest: https://dollhousemcp.com/.well-known/agent-manifest.txt
 
 # Security.txt location for security researchers
 # See https://securitytxt.org/

--- a/robots.txt
+++ b/robots.txt
@@ -6,6 +6,8 @@
 # Allow all legitimate search engines
 User-agent: *
 Allow: /
+Disallow: /docs/
+Disallow: /style-guide.html
 
 # Block bad bots and scrapers
 User-agent: AhrefsBot
@@ -15,8 +17,12 @@ User-agent: MJ12bot
 User-agent: PetalBot
 Disallow: /
 
-# Point to sitemap (when we have one)
-# Sitemap: https://dollhousemcp.com/sitemap.xml
+# Sitemap
+Sitemap: https://dollhousemcp.com/sitemap.xml
+
+# LLM and agent discovery
+llms.txt: https://dollhousemcp.com/llms.txt
+agent-manifest: https://dollhousemcp.com/.well-known/agent-manifest.txt
 
 # Security.txt location for security researchers
 # See https://securitytxt.org/


### PR DESCRIPTION
## Summary

- **`.gitignore`** — Excludes `docs/session-notes/`, `docs/development/`, `docs/security/`, and `docs/WEBSITE_EVOLUTION_PLAN.md` from future commits. Internal planning and session note files should never land in this public repo. Files currently tracked require a separate `git rm --cached` pass to untrack without deleting locally.
- **`robots.txt`** — Adds `Disallow: /docs/` and `Disallow: /style-guide.html`; uncomments the sitemap directive; adds discovery pointers to `llms.txt` and `agent-manifest.txt`.
- **`llms.txt`** — New file per [llmstxt.org](https://llmstxt.org) spec. Provides a clean, LLM-readable overview of the site with annotated links to all doc pages, all blog posts, and external resources. Used by AI tools to understand site content without crawling every page.
- **`.well-known/agent-manifest.txt`** — New file per emerging [agent-manifest standard](https://dev.to/jaspervanveen/agentstxt-a-proposed-web-standard-for-ai-agents-20lb). Declares what AI agents may/must-not do on this site, points agents to the MCP server as the preferred integration path, and documents licensing and attribution terms.

## Test plan

- [ ] Verify `https://dollhousemcp.com/robots.txt` blocks `/docs/` after deploy
- [ ] Verify `https://dollhousemcp.com/llms.txt` renders as plain text
- [ ] Verify `https://dollhousemcp.com/.well-known/agent-manifest.txt` is accessible
- [ ] Confirm `/blog/` posts are still crawlable (not blocked)
- [ ] Confirm `https://dollhousemcp.com/sitemap.xml` resolves (was already generated by jekyll-sitemap)

## Follow-up (separate PR)

`git rm --cached` pass to untrack the five already-committed internal docs files — deferred to avoid accidental local deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)