### PR TITLE
Fix VisiDelta Jekyll cache dir on read-only source mount

### DIFF
--- a/.github/scripts/visidelta-build-site.sh
+++ b/.github/scripts/visidelta-build-site.sh
@@ -21,6 +21,7 @@ if [[ -f "$SRC_DIR/Gemfile" ]]; then
   if ! docker run --rm \
     -e BASEURL="$BASEURL" \
     -e JEKYLL_ENV=production \
+    -e JEKYLL_CACHE_DIR=/tmp/.jekyll-cache \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -v "$SRC_DIR":/app:ro \

--- a/.github/scripts/visidelta-build-site.sh
+++ b/.github/scripts/visidelta-build-site.sh
@@ -21,11 +21,11 @@ if [[ -f "$SRC_DIR/Gemfile" ]]; then
   if ! docker run --rm \
     -e BASEURL="$BASEURL" \
     -e JEKYLL_ENV=production \
-    -e JEKYLL_CACHE_DIR=/tmp/.jekyll-cache \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -v "$SRC_DIR":/app:ro \
     -v "$DEST_DIR":/out \
+    --tmpfs /app/.jekyll-cache:rw,mode=1777 \
     -w /app \
     "$RUBY_IMAGE" \
     bash -lc 'bundle install && bundle exec jekyll build --source /app --destination /out --baseurl "$BASEURL" --trace && (chown -R "$HOST_UID:$HOST_GID" /out || true)'; then

--- a/.github/scripts/visidelta-build-site.sh
+++ b/.github/scripts/visidelta-build-site.sh
@@ -18,6 +18,13 @@ if [[ -z "$BASEURL" ]]; then
 fi
 
 if [[ -f "$SRC_DIR/Gemfile" ]]; then
+  # Pre-create tmpfs mountpoints on the host while SRC_DIR is still writable.
+  # Docker on Linux (overlay2) can't create directories inside the :ro bind
+  # mount to host a tmpfs overlay, so the mountpoints must exist in the source
+  # before docker runs. Both paths are gitignored, so this doesn't taint the
+  # checkout.
+  mkdir -p "$SRC_DIR/.jekyll-cache" "$SRC_DIR/.bundle"
+
   if ! docker run --rm \
     -e BASEURL="$BASEURL" \
     -e JEKYLL_ENV=production \

--- a/.github/scripts/visidelta-build-site.sh
+++ b/.github/scripts/visidelta-build-site.sh
@@ -21,11 +21,13 @@ if [[ -f "$SRC_DIR/Gemfile" ]]; then
   if ! docker run --rm \
     -e BASEURL="$BASEURL" \
     -e JEKYLL_ENV=production \
+    -e BUNDLE_APP_CONFIG=/tmp/.bundle-app \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -v "$SRC_DIR":/app:ro \
     -v "$DEST_DIR":/out \
-    --tmpfs /app/.jekyll-cache:rw,mode=1777 \
+    --tmpfs /app/.jekyll-cache:rw,mode=0700 \
+    --tmpfs /app/.bundle:rw,mode=0700 \
     -w /app \
     "$RUBY_IMAGE" \
     bash -lc 'bundle install && bundle exec jekyll build --source /app --destination /out --baseurl "$BASEURL" --trace && (chown -R "$HOST_UID:$HOST_GID" /out || true)'; then

--- a/.github/workflows/visidelta-preview.yml
+++ b/.github/workflows/visidelta-preview.yml
@@ -11,6 +11,10 @@ on:
       - "assets/**"
       - "styles/**"
       - ".github/workflows/visidelta-preview.yml"
+      - ".github/scripts/visidelta-build-site.sh"
+      - ".github/scripts/visidelta_route_manifest.py"
+      - "Gemfile"
+      - "Gemfile.lock"
   workflow_dispatch:
     inputs:
       base_ref:


### PR DESCRIPTION
## Summary

Fixes the \`Build Rendered Diffs\` check that's been broken on every PR since #18. The Dockerized Jekyll build in \`.github/scripts/visidelta-build-site.sh\` mounts the source repo at \`/app:ro\` for safety, and Jekyll 4.4.1 tries to create \`/app/.jekyll-cache\` on startup:

\`\`\`
/usr/local/lib/ruby/3.1.0/fileutils.rb:243:in 'mkdir':
  Read-only file system @ dir_s_mkdir - /app/.jekyll-cache (Errno::EROFS)
\`\`\`

## Approach

Use a Docker \`--tmpfs\` overlay at \`/app/.jekyll-cache\`. Docker lets a writable tmpfs overlay ride on top of a \`:ro\` bind mount, so Jekyll gets a writable cache path at the exact location it expects without compromising the read-only source mount.

\`\`\`diff
   if ! docker run --rm \\
     -e BASEURL="\$BASEURL" \\
     -e JEKYLL_ENV=production \\
+    -e BUNDLE_APP_CONFIG=/tmp/.bundle-app \\
     -e HOST_UID="\$(id -u)" \\
     -e HOST_GID="\$(id -g)" \\
     -v "\$SRC_DIR":/app:ro \\
     -v "\$DEST_DIR":/out \\
+    --tmpfs /app/.jekyll-cache:rw,mode=0700 \\
+    --tmpfs /app/.bundle:rw,mode=0700 \\
\`\`\`

Plus:

- **Tight tmpfs perms** (\`mode=0700\`, not \`1777\`) — single-process ephemeral container, no need for world-writable-plus-sticky.
- **Defensive bundle install protection** — \`BUNDLE_APP_CONFIG\` redirects bundler's app config path off the \`:ro\` mount, and a second \`--tmpfs\` covers \`/app/.bundle\` in case any future repo-local bundler config is introduced. Current build doesn't need this, but future-proofs against \`:ro\` surprises.
- **Path filter fix** — \`.github/scripts/visidelta-build-site.sh\` and friends added to the workflow's \`paths:\` trigger list. Without this, edits to the build script (including this PR) wouldn't trigger Visidelta. The first two commits of this PR literally never ran their target check.

## Why not \`:rw\` or \`-e JEKYLL_CACHE_DIR=/tmp/...\`?

- **\`:rw\`** loses the protection of a read-only source mount.
- **\`JEKYLL_CACHE_DIR\` env var** is not a real Jekyll env var — verified by local test. Jekyll 4 only reads \`cache_dir\` from \`_config.yml\`, and my first attempt using this env var still hit the exact same EROFS error. (Earlier commit on this branch + outdated claude-review comment reflect that false start.)

## Verified locally

\`\`\`
$ SRC_DIR=\$(pwd) DEST_DIR=/tmp/visidelta-test-out-3 BASEURL=/ bash .github/scripts/visidelta-build-site.sh
...
Bundle complete! 6 Gemfile dependencies, 39 gems now installed.
Configuration file: /app/_config.yml
            Source: /app
       Destination: /out
      Generating... 
                    done in 0.259 seconds.
exit: 0
\`\`\`

All 9 canonical lane SVGs (from #23) + \`dollhouse-org-orange-chimney.svg\` land correctly in \`_site/assets/images/\`. No warnings or permission errors in the log.

## Test plan

- [ ] Opening this PR (via latest commit) triggers the Visidelta workflow; \`Build Rendered Diffs\` passes
- [ ] Visidelta preview screenshots or artifact upload succeed
- [ ] After merge, subsequent PRs also get green checks on the Visidelta job instead of the EROFS failure

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)