### PR TITLE
Make lychee resilient to transient GitHub 5xx/429

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,6 +1,10 @@
-max_retries = 2
-retry_wait_time = 2
-timeout = 20
+# Retry generously: the security pages cite ~34 github.com/.../blob/main
+# source links, and GitHub intermittently returns 429/502 under that
+# volume. More retries with a longer backoff rides out transient 5xx/429
+# without masking real failures — a genuine 404 still fails after retries.
+max_retries = 5
+retry_wait_time = 4
+timeout = 30
 no_progress = true
 exclude = [
   "https://www.linkedin.com/.*",


### PR DESCRIPTION
## Problem

Link Check on PR #34 (develop→main) failed on a transient **GitHub 502 Bad Gateway** for a valid source link (`autonomyEvaluator.ts`), while a concurrent run on the same commit passed. The `/security/` section cites ~34 `github.com/.../blob/main/...` links; GitHub intermittently throttles/502s under that volume, so Link Check fails non-deterministically.

## Fix

`.lychee.toml`: `max_retries` 2→5, `retry_wait_time` 2s→4s, `timeout` 20s→30s. Transient 5xx/429 are retried out; a genuine 404 still fails after the retries, so no link-checking coverage is lost.

Targets `develop` per GitFlow; flows into the pending `develop`→`main` release (#34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)